### PR TITLE
Include media whenever retrieving entertainers

### DIFF
--- a/__tests__/controllers/entertainersController.test.js
+++ b/__tests__/controllers/entertainersController.test.js
@@ -3,9 +3,11 @@ const express = require("express");
 const bodyParser = require("body-parser");
 const {
   getEntertainerById,
+  getEntertainers,
 } = require("../../controllers/entertainersControllers");
 const {
   fetchEntertainerById,
+  fetchEntertainers,
   fetchUserMediaByUserId,
 } = require("../../models/entertainersModels");
 
@@ -14,6 +16,7 @@ jest.mock("../../models/entertainersModels");
 const app = express();
 app.use(bodyParser.json());
 app.get("/api/entertainers/:user_id", getEntertainerById);
+app.get("/api/entertainers", getEntertainers);
 
 describe("GET /api/entertainers/:user_id", () => {
   afterEach(() => {
@@ -62,8 +65,9 @@ describe("GET /api/entertainers/:user_id", () => {
       description: "A master of balance and coordination...",
       price: 20,
       created_at: "2024-07-03T19:35:37.535Z",
-      media: mockMedia,
+      media: expect.any(Array),
     });
+    expect(response.body.entertainer.media).toEqual(mockMedia);
     expect(response.body.entertainer).not.toHaveProperty("password");
   });
 
@@ -75,5 +79,105 @@ describe("GET /api/entertainers/:user_id", () => {
       .expect(404);
 
     expect(response.body).toEqual({ error: "Entertainer not found" });
+  });
+});
+
+describe("GET /api/entertainers", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("200: responds with an array of entertainer objects without passwords and includes media", async () => {
+    const mockEntertainers = [
+      {
+        user_id: 1,
+        username: "j_depp",
+        password: "hashedpassword",
+        first_name: "Johnny",
+        last_name: "Depp",
+        email: "j.depp@gmail.com",
+        profile_img_url: "",
+        user_type: "Entertainer",
+        category: "Juggler",
+        location: "London",
+        entertainer_name: "Johnny the Juggler",
+        description: "A master of balance and coordination...",
+        price: 20,
+        created_at: "2024-07-03T19:35:37.535Z",
+      },
+      {
+        user_id: 2,
+        username: "a_smith",
+        password: "hashedpassword",
+        first_name: "Anna",
+        last_name: "Smith",
+        email: "a.smith@gmail.com",
+        profile_img_url: "",
+        user_type: "Entertainer",
+        category: "Singer",
+        location: "Manchester",
+        entertainer_name: "Anna the Singer",
+        description: "A master of singing...",
+        price: 30,
+        created_at: "2024-07-03T19:35:37.535Z",
+      },
+    ];
+
+    const mockMedia1 = [
+      { url: "https://example.com/media1.jpg" },
+      { url: "https://example.com/media2.jpg" },
+    ];
+
+    const mockMedia2 = [
+      { url: "https://example.com/media3.jpg" },
+      { url: "https://example.com/media4.jpg" },
+    ];
+
+    fetchEntertainers.mockResolvedValue(mockEntertainers);
+    fetchUserMediaByUserId
+      .mockResolvedValueOnce(mockMedia1)
+      .mockResolvedValueOnce(mockMedia2);
+
+    const response = await request(app).get("/api/entertainers").expect(200);
+
+    expect(response.body.entertainers).toHaveLength(2);
+
+    expect(response.body.entertainers[0]).toMatchObject({
+      user_id: 1,
+      username: "j_depp",
+      first_name: "Johnny",
+      last_name: "Depp",
+      email: "j.depp@gmail.com",
+      profile_img_url: "",
+      user_type: "Entertainer",
+      category: "Juggler",
+      location: "London",
+      entertainer_name: "Johnny the Juggler",
+      description: "A master of balance and coordination...",
+      price: 20,
+      created_at: "2024-07-03T19:35:37.535Z",
+      media: expect.any(Array),
+    });
+    expect(response.body.entertainers[0].media).toEqual(mockMedia1);
+    expect(response.body.entertainers[0]).not.toHaveProperty("password");
+
+    expect(response.body.entertainers[1]).toMatchObject({
+      user_id: 2,
+      username: "a_smith",
+      first_name: "Anna",
+      last_name: "Smith",
+      email: "a.smith@gmail.com",
+      profile_img_url: "",
+      user_type: "Entertainer",
+      category: "Singer",
+      location: "Manchester",
+      entertainer_name: "Anna the Singer",
+      description: "A master of singing...",
+      price: 30,
+      created_at: "2024-07-03T19:35:37.535Z",
+      media: expect.any(Array),
+    });
+    expect(response.body.entertainers[1].media).toEqual(mockMedia2);
+    expect(response.body.entertainers[1]).not.toHaveProperty("password");
   });
 });

--- a/__tests__/controllers/entertainersController.test.js
+++ b/__tests__/controllers/entertainersController.test.js
@@ -4,7 +4,10 @@ const bodyParser = require("body-parser");
 const {
   getEntertainerById,
 } = require("../../controllers/entertainersControllers");
-const { fetchEntertainerById } = require("../../models/entertainersModels");
+const {
+  fetchEntertainerById,
+  fetchUserMediaByUserId,
+} = require("../../models/entertainersModels");
 
 jest.mock("../../models/entertainersModels");
 
@@ -17,7 +20,7 @@ describe("GET /api/entertainers/:user_id", () => {
     jest.resetAllMocks();
   });
 
-  test("200: responds with correct entertainer object without password", async () => {
+  test("200: responds with correct entertainer object without password and includes media", async () => {
     const mockEntertainer = {
       user_id: 1,
       username: "j_depp",
@@ -35,7 +38,13 @@ describe("GET /api/entertainers/:user_id", () => {
       created_at: "2024-07-03T19:35:37.535Z",
     };
 
+    const mockMedia = [
+      { url: "https://example.com/media1.jpg" },
+      { url: "https://example.com/media2.jpg" },
+    ];
+
     fetchEntertainerById.mockResolvedValue(mockEntertainer);
+    fetchUserMediaByUserId.mockResolvedValue(mockMedia);
 
     const response = await request(app).get("/api/entertainers/1").expect(200);
 
@@ -53,6 +62,7 @@ describe("GET /api/entertainers/:user_id", () => {
       description: "A master of balance and coordination...",
       price: 20,
       created_at: "2024-07-03T19:35:37.535Z",
+      media: mockMedia,
     });
     expect(response.body.entertainer).not.toHaveProperty("password");
   });

--- a/__tests__/integration-tests.js
+++ b/__tests__/integration-tests.js
@@ -160,11 +160,11 @@ describe("GET /api/entertainers?date", () => {
 describe("GET /api/entertainers/:user_id", () => {
   test("200: responds with correct entertainer object", () => {
     return request(app)
-      .get("/api/entertainers/2")
+      .get("/api/entertainers/1")
       .expect(200)
       .then(({ body }) => {
         expect(body.entertainer).toMatchObject({
-          user_id: 2,
+          user_id: 1,
           username: expect.any(String),
           first_name: expect.any(String),
           last_name: expect.any(String),
@@ -177,6 +177,11 @@ describe("GET /api/entertainers/:user_id", () => {
           entertainer_name: expect.any(String),
           description: expect.any(String),
           price: expect.any(Number),
+          media: expect.any(Array)
+        });
+        expect(body.entertainer.media).toHaveLength(2);
+        expect(body.entertainer.media[0]).toMatchObject({
+          url: expect.any(String)
         });
       });
   });

--- a/__tests__/integration-tests.js
+++ b/__tests__/integration-tests.js
@@ -223,6 +223,7 @@ describe("GET /api/entertainers", () => {
             entertainer_name: expect.any(String),
             description: expect.any(String),
             price: expect.any(Number),
+            media: expect.any(Array)
           });
           expect(entertainer).not.toHaveProperty("password");
         });
@@ -259,6 +260,7 @@ describe("GET /api/entertainers?location", () => {
             entertainer_name: expect.any(String),
             description: expect.any(String),
             price: expect.any(Number),
+            media: expect.any(Array)
           });
           expect(entertainer).not.toHaveProperty("password");
         });
@@ -294,6 +296,7 @@ describe("GET /api/entertainers?category", () => {
             entertainer_name: expect.any(String),
             description: expect.any(String),
             price: expect.any(Number),
+            media: expect.any(Array)
           });
           expect(entertainer).not.toHaveProperty("password");
         });
@@ -329,6 +332,7 @@ describe("GET /api/entertainers?date", () => {
             entertainer_name: expect.any(String),
             description: expect.any(String),
             price: expect.any(Number),
+            media: expect.any(Array)
           });
           expect(entertainer).not.toHaveProperty("password");
         });
@@ -363,6 +367,7 @@ describe("GET /api/entertainers/:user_id", () => {
           entertainer_name: expect.any(String),
           description: expect.any(String),
           price: expect.any(Number),
+          media: expect.any(Array)
         });
         expect(body.entertainer).not.toHaveProperty("password");
       });

--- a/__tests__/integration-tests.js
+++ b/__tests__/integration-tests.js
@@ -170,7 +170,6 @@ describe("GET /api/entertainers/:user_id", () => {
           last_name: expect.any(String),
           email: expect.any(String),
           profile_img_url: expect.any(String),
-          urls: expect.any(Array),
           user_type: "Entertainer",
           category: expect.any(String),
           location: expect.any(String),
@@ -180,9 +179,6 @@ describe("GET /api/entertainers/:user_id", () => {
           media: expect.any(Array)
         });
         expect(body.entertainer.media).toHaveLength(2);
-        expect(body.entertainer.media[0]).toMatchObject({
-          url: expect.any(String)
-        });
       });
   });
   test("404: Not Found", () => {

--- a/controllers/entertainersControllers.js
+++ b/controllers/entertainersControllers.js
@@ -24,7 +24,8 @@ exports.getEntertainers = async (req, res, next) => {
 
     const entertainersWithMedia = await Promise.all(entertainers.map(async (user) => {
       const { password, ...userWithoutPassword } = user;
-      const media = await fetchUserMediaByUserId(user.user_id);
+      const mediaObjects = await fetchUserMediaByUserId(user.user_id);
+      const media = mediaObjects.map(mediaObj => mediaObj.url);
       return { ...userWithoutPassword, media };
     }));
 
@@ -37,11 +38,10 @@ exports.getEntertainers = async (req, res, next) => {
 exports.getEntertainerById = (req, res, next) => {
   const { user_id } = req.params;
 
-  Promise.all([fetchEntertainerById(user_id), fetchUserMediaByUserId(user_id)])
-    .then(([entertainer, media]) => {
+  Promise.all([fetchEntertainerById(user_id)])
+    .then(([entertainer]) => {
       if (entertainer) {
         const { password, ...entertainerWithoutPassword } = entertainer;
-        entertainerWithoutPassword.media = media;
         res.status(200).send({ entertainer: entertainerWithoutPassword });
       } else {
         res.status(404).send({ error: "Entertainer not found" });

--- a/controllers/entertainersControllers.js
+++ b/controllers/entertainersControllers.js
@@ -2,6 +2,7 @@ const { checkCategoryIsValid } = require("../models/categoriesModels");
 const {
   fetchEntertainers,
   fetchEntertainerById,
+  fetchUserMediaByUserId
 } = require("../models/entertainersModels");
 const { checkLocationIsValid } = require("../models/locationsModels");
 
@@ -30,10 +31,12 @@ exports.getEntertainers = (req, res, next) => {
 
 exports.getEntertainerById = (req, res, next) => {
   const { user_id } = req.params;
-  fetchEntertainerById(user_id)
-    .then((entertainer) => {
+
+  Promise.all([fetchEntertainerById(user_id), fetchUserMediaByUserId(user_id)])
+    .then(([entertainer, media]) => {
       if (entertainer) {
         const { password, ...entertainerWithoutPassword } = entertainer;
+        entertainerWithoutPassword.media = media;
         res.status(200).send({ entertainer: entertainerWithoutPassword });
       } else {
         res.status(404).send({ error: "Entertainer not found" });

--- a/db/data/test-data/userMedia.js
+++ b/db/data/test-data/userMedia.js
@@ -1,17 +1,22 @@
-module.exports = [{
-    url: 'https://cdn.britannica.com/89/152989-050-DDF277EA/Johnny-Depp-2011.jpg',
+module.exports = [
+  {
+    url: "https://cdn.britannica.com/89/152989-050-DDF277EA/Johnny-Depp-2011.jpg",
     user_id: 1,
-},
-{
-    url: 'https://upload.wikimedia.org/wikipedia/commons/7/7f/Emma_Watson_2013.jpg',
-    user_id: 2
-},
-{
-    url: 'https://img.huffingtonpost.com/asset/661e23ea2200008623fc6d32.jpeg?cache=Avj37YZQ0T&ops=crop_528_121_1719_1077%2Cscalefit_500_noupscale',
-    user_id: 3
-},
-{
-    url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/cb/Dame_Maggie_Smith_1973_%28fro[…]-Dame_Maggie_Smith_1973_%28front_side%29_%28cropped%29.jpg',
-    user_id: 6
-}
-]
+  },
+  {
+    url: "https://scontent-lhr8-1.xx.fbcdn.net/v/t39.30808-6/374951687_847460096946257_7235390906745152296_n.jpg?_nc_cat=111&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=MOWYv332CwYQ7kNvgEFye4t&_nc_ht=scontent-lhr8-1.xx&oh=00_AYDmXq-3YbGRaPYHxd0UFabizBNvF6Wv8_rk9GQt5BKGeg&oe=668B7C35",
+    user_id: 1,
+  },
+  {
+    url: "https://upload.wikimedia.org/wikipedia/commons/7/7f/Emma_Watson_2013.jpg",
+    user_id: 2,
+  },
+  {
+    url: "https://img.huffingtonpost.com/asset/661e23ea2200008623fc6d32.jpeg?cache=Avj37YZQ0T&ops=crop_528_121_1719_1077%2Cscalefit_500_noupscale",
+    user_id: 3,
+  },
+  {
+    url: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/cb/Dame_Maggie_Smith_1973_%28fro[…]-Dame_Maggie_Smith_1973_%28front_side%29_%28cropped%29.jpg",
+    user_id: 6,
+  },
+];

--- a/endpoints.json
+++ b/endpoints.json
@@ -18,7 +18,10 @@
         "location": "London",
         "entertainer_name": "Johnny the Juggler",
         "description": "A master of balance and coordination, this juggler dazzles audiences with a variety of props including balls, clubs, and rings. Known for their high-energy performances and humorous interactions, they bring a playful and captivating experience to any event",
-        "price": 20
+        "price": 20,
+        "media": [
+        "https://upload.wikimedia.org/wikipedia/commons/7/7f/Emma_Watson_2013.jpg"
+      ]
       }
     ]
   },
@@ -38,7 +41,7 @@
       "entertainer_name": "Emma the Violin Virtuoso",
       "description": "A highly skilled violinist with years of experience, Emma delivers soulful and captivating performances. Perfect for weddings, events, and private concerts.",
       "price": 30,
-      "urls": [
+      "media": [
         "https://upload.wikimedia.org/wikipedia/commons/7/7f/Emma_Watson_2013.jpg"
       ]
     }

--- a/models/entertainersModels.js
+++ b/models/entertainersModels.js
@@ -57,11 +57,11 @@ exports.fetchEntertainerById = (user_id) => {
     }
 
     const user = resolvedPromises[0].rows[0];
-    user.urls = [];
+    user.media = [];
     const images = resolvedPromises[1].rows;
 
     images.forEach((image) => {
-      user.urls.push(image.url);
+      user.media.push(image.url);
     });
 
     return user;

--- a/models/entertainersModels.js
+++ b/models/entertainersModels.js
@@ -1,63 +1,77 @@
-const db = require('../db/connection')
+const db = require("../db/connection");
 
 exports.fetchEntertainers = (location, category, date) => {
-   
-    let queryString = `SELECT users.user_id, users.username, users.first_name, users.last_name, users.email, users.profile_img_url, users.user_type, users.category, users.location, users.entertainer_name, users.description, users.price FROM users`
+  let queryString = `SELECT users.user_id, users.username, users.first_name, users.last_name, users.email, users.profile_img_url, users.user_type, users.category, users.location, users.entertainer_name, users.description, users.price FROM users`;
+  let queryValues = [];
+  const correctDateRegex =
+    /^\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])$/;
 
-    let queryValues = []
-
-    const correctDateRegex = /^\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])$/
-
-    if(date){
-        if(correctDateRegex.test(date)){
-        queryString += ` JOIN availability ON users.user_id = availability.entertainer_id  WHERE user_type = 'Entertainer' AND date = $1 AND available = true`
-        queryValues.push(date)}
-        else{return Promise.reject({status: 404, msg: '404: Not Found'})}
+  if (date) {
+    if (correctDateRegex.test(date)) {
+      queryString += ` JOIN availability ON users.user_id = availability.entertainer_id  WHERE user_type = 'Entertainer' AND date = $1 AND available = true`;
+      queryValues.push(date);
+    } else {
+      return Promise.reject({ status: 404, msg: "404: Not Found" });
     }
-    else{queryString += ` WHERE user_type = 'Entertainer'`}
+  } else {
+    queryString += ` WHERE user_type = 'Entertainer'`;
+  }
 
-
-    if(location){
-        if(date){` AND location = $2`}
-        else{queryString += ` AND location = $1`}
-        queryValues.push(location)
+  if (location) {
+    if (date) {
+      ` AND location = $2`;
+    } else {
+      queryString += ` AND location = $1`;
     }
-    
-    if(category){
-        if(location && date){queryString += ` AND category = $3`}
-        else if(location || date){queryString += ` AND category = $2`}
-        else{queryString += ` AND category = $1`}
-        queryValues.push(category)
+    queryValues.push(location);
+  }
+
+  if (category) {
+    if (location && date) {
+      queryString += ` AND category = $3`;
+    } else if (location || date) {
+      queryString += ` AND category = $2`;
+    } else {
+      queryString += ` AND category = $1`;
     }
+    queryValues.push(category);
+  }
 
-   
-
-    return db.query(queryString, queryValues).then((result) => {
-        return result.rows
-    })
-}
+  return db.query(queryString, queryValues).then((result) => {
+    return result.rows;
+  });
+};
 
 exports.fetchEntertainerById = (user_id) => {
+  const userPromise = db.query(
+    `SELECT users.user_id, users.username, users.first_name, users.last_name, users.email, users.profile_img_url, users.user_type, users.category, users.location, users.entertainer_name, users.description, users.price FROM users WHERE user_type = 'Entertainer' AND users.user_id = $1;`,
+    [user_id]
+  );
+  const urlPromise = db.query(`SELECT url FROM userMedia WHERE user_id = $1`, [
+    user_id,
+  ]);
 
-    const userPromise =  db.query(`SELECT users.user_id, users.username, users.first_name, users.last_name, users.email, users.profile_img_url, users.user_type, users.category, users.location, users.entertainer_name, users.description, users.price FROM users WHERE user_type = 'Entertainer' AND users.user_id = $1;`, [user_id])
-    const urlPromise = db.query(`SELECT url FROM userMedia WHERE user_id = $1`, [user_id])
-   
-   return Promise.all([userPromise, urlPromise])
-
-.then((resolvedPromises) => {
-    if(resolvedPromises[0].rows.length === 0){
-        return Promise.reject({status: 404, msg: '404: Not Found'})
+  return Promise.all([userPromise, urlPromise]).then((resolvedPromises) => {
+    if (resolvedPromises[0].rows.length === 0) {
+      return Promise.reject({ status: 404, msg: "404: Not Found" });
     }
-    
-    const user = resolvedPromises[0].rows[0]
-    user.urls = []
-    const images = resolvedPromises[1].rows
+
+    const user = resolvedPromises[0].rows[0];
+    user.urls = [];
+    const images = resolvedPromises[1].rows;
 
     images.forEach((image) => {
-        user.urls.push(image.url)
-    })
-    
-    
-    return user
-})
-}
+      user.urls.push(image.url);
+    });
+
+    return user;
+  });
+};
+
+exports.fetchUserMediaByUserId = (user_id) => {
+  return db
+    .query("SELECT url FROM userMedia WHERE user_id = $1", [user_id])
+    .then((result) => {
+      return result.rows;
+    });
+};


### PR DESCRIPTION
When retrieving entertainers*, the json payload will include `media` (previously `urls`), example payload:

```json
{
	"entertainer": {
		"user_id": 1,
		"username": "j_depp",
		"first_name": "Johnny",
		"last_name": "Depp",
		"email": "j.depp@gmail.com",
		"profile_img_url": "https://cdn.britannica.com/89/152989-050-DDF277EA/Johnny-Depp-2011.jpg",
		"user_type": "Entertainer",
		"category": "Juggler",
		"location": "London",
		"entertainer_name": "Johnny the Juggler",
		"description": "A master of balance and coordination, this juggler dazzles audiences with a variety of props including balls, clubs, and rings. Known for their high-energy performances and humorous interactions, they bring a playful and captivating experience to any event",
		"price": 20,
		"media": [
			"https://cdn.britannica.com/89/152989-050-DDF277EA/Johnny-Depp-2011.jpg",
			"https://scontent-lhr8-1.xx.fbcdn.net/v/t39.30808-6/374951687_847460096946257_7235390906745152296_n.jpg?_nc_cat=111&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=MOWYv332CwYQ7kNvgEFye4t&_nc_ht=scontent-lhr8-1.xx&oh=00_AYDmXq-3YbGRaPYHxd0UFabizBNvF6Wv8_rk9GQt5BKGeg&oe=668B7C35"
		]
	}
}
```

** All API endpoints to retrieve entertainers, not just by id.